### PR TITLE
hash.h and string_view are in utils, small fix

### DIFF
--- a/util/string_view.h
+++ b/util/string_view.h
@@ -10,7 +10,7 @@
 #ifndef META_UTIL_STRING_VIEW_H_
 #define META_UTIL_STRING_VIEW_H_
 
-#include "util/hash.h"
+#include "hash.h"
 
 #if META_HAS_EXPERIMENTAL_STRING_VIEW
 #include <experimental/string_view>


### PR DESCRIPTION
The directory utils in the #include statement for string_view is unnecessary; both files are in same directory -- in the given form I was not able to compile. Small fix helped.